### PR TITLE
added if function check before sortBy execution

### DIFF
--- a/projects/ng-datatable/src/lib/DataTable.ts
+++ b/projects/ng-datatable/src/lib/DataTable.ts
@@ -166,7 +166,7 @@ export class DataTable implements OnChanges, DoCheck {
                         value = value[sortByProperty];
                     }
                 }
-            } else {
+            } else if (typeof sortBy === "function") {
                 value = sortBy(value);
             }
 


### PR DESCRIPTION
Fix for "Uncaught TypeError: sortBy is not a function when sortBy is undefined" https://github.com/PascalHonegger/ng-datatable/issues/11 issue

